### PR TITLE
Detect .FIT files

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func new() *cobra.Command {
 			log.Printf("Processing %d files\n", len(files))
 
 			for _, f := range files {
-				if f.IsDir() || strings.HasPrefix(f.Name(), ".") || !strings.HasSuffix(f.Name(), ".fit") {
+				if f.IsDir() || strings.HasPrefix(f.Name(), ".") || !strings.HasSuffix(strings.ToLower(f.Name()), ".fit") {
 					log.Printf("Ignoring %s\n", f.Name())
 					continue
 				}


### PR DESCRIPTION
Hello, thank you for this tool, it works superbly! :1st_place_medal: 

This allows to detect both .fit and .FIT files as some devices (e.g. Garmin Edge 25) store files in uppercase (e.g. `C61J3030.FIT`).